### PR TITLE
docs: add backend README with setup and architecture

### DIFF
--- a/backend/MoodTrackerAPI/README.md
+++ b/backend/MoodTrackerAPI/README.md
@@ -1,0 +1,36 @@
+﻿# Daily Mood Tracker
+
+## 📌 Descriere
+Daily Mood Tracker este o aplicație care permite utilizatorilor să își noteze starea zilnică, să adauge o notiță și să vizualizeze istoricul și statistici.
+
+---
+
+## 🧱 Arhitectură
+Aplicația este construită pe arhitectură **Client-Server**:
+
+- **Frontend:** 
+- **Backend:** ASP.NET Core Web API
+- **Database:** 
+
+Backend-ul este organizat folosind **Layered Architecture**:
+- Controllers
+- Services
+- Models
+- Data
+
+---
+
+## ⚙️ Tehnologii folosite
+- C#
+- ASP.NET Core Web API
+- Swagger / OpenAPI
+- Git & GitHub
+- Docker (în curs de integrare)
+
+---
+
+## 🚀 Setup backend
+
+1. Clonare repository:
+```bash
+git clone https://github.com/nastase1/mpi-project.git


### PR DESCRIPTION
Closes #5 

- Added backend README
- Includes setup instructions
- Includes architecture details