### PR TITLE
feat: add unit tests for MoodEntryService

### DIFF
--- a/backend/MoodTrackerAPI.Tests/MoodEntryServiceTests.cs
+++ b/backend/MoodTrackerAPI.Tests/MoodEntryServiceTests.cs
@@ -1,0 +1,110 @@
+﻿using Microsoft.EntityFrameworkCore;
+using MoodTrackerAPI.Data;
+using MoodTrackerAPI.Models;
+using MoodTrackerAPI.Services;
+using Xunit;
+
+namespace MoodTrackerAPI.Tests
+{
+    public class MoodEntryServiceTests
+    {
+        private AppDbContext GetDbContext()
+        {
+            var options = new DbContextOptionsBuilder<AppDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+
+            return new AppDbContext(options);
+        }
+
+        [Fact]
+        public async Task CreateAsync_AddsEntry()
+        {
+            var context = GetDbContext();
+            var service = new MoodEntryService(context);
+
+            var entry = new MoodEntry
+            {
+                Date = DateTime.UtcNow,
+                Mood = "Happy",
+                Note = "Test"
+            };
+
+            var result = await service.CreateAsync(entry);
+
+            Assert.NotNull(result);
+            Assert.Equal(1, context.MoodEntries.Count());
+        }
+
+        [Fact]
+        public async Task GetAllAsync_ReturnsEntries()
+        {
+            var context = GetDbContext();
+            var service = new MoodEntryService(context);
+
+            context.MoodEntries.Add(new MoodEntry
+            {
+                Date = DateTime.UtcNow,
+                Mood = "Ok"
+            });
+            await context.SaveChangesAsync();
+
+            var result = await service.GetAllAsync();
+
+            Assert.Single(result);
+        }
+
+        [Fact]
+        public async Task GetByIdAsync_ReturnsCorrectEntry()
+        {
+            var context = GetDbContext();
+            var service = new MoodEntryService(context);
+
+            var entry = new MoodEntry
+            {
+                Date = DateTime.UtcNow,
+                Mood = "Good"
+            };
+
+            context.MoodEntries.Add(entry);
+            await context.SaveChangesAsync();
+
+            var result = await service.GetByIdAsync(entry.Id);
+
+            Assert.NotNull(result);
+            Assert.Equal(entry.Id, result!.Id);
+        }
+
+        [Fact]
+        public async Task DeleteAsync_RemovesEntry()
+        {
+            var context = GetDbContext();
+            var service = new MoodEntryService(context);
+
+            var entry = new MoodEntry
+            {
+                Date = DateTime.UtcNow,
+                Mood = "Sad"
+            };
+
+            context.MoodEntries.Add(entry);
+            await context.SaveChangesAsync();
+
+            var result = await service.DeleteAsync(entry.Id);
+
+            Assert.True(result);
+            Assert.Empty(context.MoodEntries);
+        }
+
+        [Fact]
+        public async Task DeleteAsync_ReturnsFalse_WhenNotFound()
+        {
+            var context = GetDbContext();
+            var service = new MoodEntryService(context);
+
+            var result = await service.DeleteAsync(Guid.NewGuid());
+
+            Assert.False(result);
+        }
+    }
+}

--- a/backend/MoodTrackerAPI.Tests/MoodTrackerAPI.Tests.csproj
+++ b/backend/MoodTrackerAPI.Tests/MoodTrackerAPI.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MoodTrackerAPI\MoodTrackerAPI.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/backend/MoodTrackerAPI/MoodTrackerAPI.sln
+++ b/backend/MoodTrackerAPI/MoodTrackerAPI.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MoodTrackerAPI", "MoodTrack
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{3221428C-F87C-4C39-AF5B-590D52423C45}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MoodTrackerAPI.Tests", "..\MoodTrackerAPI.Tests\MoodTrackerAPI.Tests.csproj", "{AF66AEEA-6C4F-47B7-981D-3EF3BB1D8A37}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -17,6 +19,10 @@ Global
 		{37BC5BE1-316B-4274-802D-37845FC494FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{37BC5BE1-316B-4274-802D-37845FC494FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{37BC5BE1-316B-4274-802D-37845FC494FE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AF66AEEA-6C4F-47B7-981D-3EF3BB1D8A37}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AF66AEEA-6C4F-47B7-981D-3EF3BB1D8A37}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AF66AEEA-6C4F-47B7-981D-3EF3BB1D8A37}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AF66AEEA-6C4F-47B7-981D-3EF3BB1D8A37}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/backend/MoodTrackerAPI/README.md
+++ b/backend/MoodTrackerAPI/README.md
@@ -1,31 +1,106 @@
-﻿# Daily Mood Tracker
+﻿# Daily Mood Tracker - Backend
 
 ## 📌 Descriere
-Daily Mood Tracker este o aplicație care permite utilizatorilor să își noteze starea zilnică, să adauge o notiță și să vizualizeze istoricul și statistici.
+Daily Mood Tracker este o aplicație care permite utilizatorilor să își noteze starea zilnică, să adauge o notiță și să vizualizeze istoricul.
+
+Acest repository conține partea de **backend**, responsabilă pentru gestionarea datelor și expunerea unui API REST.
 
 ---
 
 ## 🧱 Arhitectură
+
 Aplicația este construită pe arhitectură **Client-Server**:
 
-- **Frontend:** 
+- **Frontend:** (în dezvoltare / realizat de colegi)
 - **Backend:** ASP.NET Core Web API
-- **Database:** 
+- **Database:** SQL Server (LocalDB)
 
 Backend-ul este organizat folosind **Layered Architecture**:
-- Controllers
-- Services
-- Models
-- Data
+- **Controllers** – expun endpointurile API
+- **Services** – conțin logica de business
+- **Models** – definesc structura datelor
+- **Data** – configurarea bazei de date (DbContext)
 
 ---
 
 ## ⚙️ Tehnologii folosite
+
 - C#
-- ASP.NET Core Web API
+- ASP.NET Core Web API (.NET 8)
+- Entity Framework Core
+- SQL Server (LocalDB)
 - Swagger / OpenAPI
+- xUnit (pentru teste)
 - Git & GitHub
 - Docker (în curs de integrare)
+
+---
+
+## 🗄️ Baza de date
+
+- ORM folosit: **Entity Framework Core**
+- Migrații utilizate pentru crearea tabelelor
+- Tabel principal: `MoodEntries`
+
+### Structura MoodEntry:
+- `Id` (Guid)
+- `Date` (DateTime)
+- `Mood` (string)
+- `Note` (string, opțional)
+
+---
+
+## 🔌 API Endpoints
+
+### MoodEntries
+
+- `GET /api/MoodEntries`  
+  → returnează toate înregistrările
+
+- `GET /api/MoodEntries/{id}`  
+  → returnează o înregistrare după id
+
+- `POST /api/MoodEntries`  
+  → creează o înregistrare nouă
+
+- `DELETE /api/MoodEntries/{id}`  
+  → șterge o înregistrare
+
+---
+
+## ⚠️ Validări și erori
+
+- Returnează **400 BadRequest** pentru date invalide:
+  - mood gol
+  - dată din viitor
+- Returnează **404 NotFound** dacă resursa nu există
+- Returnează **201 Created** la creare
+- Returnează **204 NoContent** la ștergere
+
+---
+
+## 🧠 Logică implementată
+
+- separare clară Controller → Service → Data
+- folosirea Dependency Injection
+- tratament corect al status codes
+- validare input în controller
+
+---
+
+## 🧪 Teste
+
+Au fost implementate **teste unitare** pentru `MoodEntryService` folosind:
+
+- xUnit
+- EF Core InMemory
+
+Testele acoperă:
+- creare MoodEntry
+- returnare listă
+- returnare după id
+- ștergere
+- cazuri negative (element inexistent)
 
 ---
 


### PR DESCRIPTION
## What this PR does
- adds unit tests for MoodEntryService
- covers create, get, and delete scenarios
- uses EF Core InMemory for testing

Closes #18 